### PR TITLE
一覧表示ビューの「画像/価格/商品名」の表示

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -143,10 +143,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>


### PR DESCRIPTION
What
ユーザーの出品商品をトップページで一覧できる機能の実装

Why
出品されている商品を一覧表示することで、全てのユーザーが売買するための商品の売買状況を簡単に把握できるため

商品出品後画面
https://gyazo.com/9cca406ecb67346dcd76a103c4a77da8