### PR TITLE
destroyアクションの設定

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,8 +21,11 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item.destroy
+    if @item.destroy
     redirect_to root_path
+    else
+    redirct_to edit_item_path
+    end
   end
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
-  before_action :set_item, only: [:edit, :update, :show]
+  before_action :set_item, only: [:edit, :update, :show, :destroy]
 
 
   def index
@@ -19,6 +19,12 @@ class ItemsController < ApplicationController
       render :new
     end
   end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
+  end
+
 
   def edit
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,6 @@ class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
   before_action :set_item, only: [:edit, :update, :show, :destroy]
 
-
   def index
     @items = Item.includes(:user)
   end
@@ -22,12 +21,11 @@ class ItemsController < ApplicationController
 
   def destroy
     if @item.destroy
-    redirect_to root_path
+      redirect_to root_path
     else
-    redirct_to edit_item_path
+      redirct_to edit_item_path
     end
   end
-
 
   def edit
   end
@@ -40,7 +38,6 @@ class ItemsController < ApplicationController
     end
   end
 
-
   def show
   end
 
@@ -48,7 +45,7 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:item_name, :image, :text, :price, :category_id, :status_id, :delivery_fee_id, :option_id,
-    :shipping_day_id ).merge(user_id: current_user.id)
+                                 :shipping_day_id).merge(user_id: current_user.id)
   end
 
   def set_item

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -6,11 +6,10 @@ class Category < ActiveHash::Base
     { id: 4, name: 'ベビー・キッズ' },
     { id: 5, name: 'インテリア・住まい・小物' },
     { id: 6, name: '本・音楽・ゲーム' },
-    { id: 7, name: 'おもちゃ・ホビー・グッズ'},
+    { id: 7, name: 'おもちゃ・ホビー・グッズ' },
     { id: 8, name: '家電・スマホ・カメラ' },
     { id: 9, name: 'スピオーツ・レジャー' },
     { id: 10, name: 'ハンドメイド' },
     { id: 11, name: 'その他' }
   ]
-  end
- 
+end

--- a/app/models/delivery_fee.rb
+++ b/app/models/delivery_fee.rb
@@ -4,5 +4,4 @@ class DeliveryFee < ActiveHash::Base
     { id: 2, name: '着払い（購入者負担）' },
     { id: 3, name: '送料込み（出品者負担）' }
   ]
-  end
- 
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,7 +2,6 @@ class Item < ApplicationRecord
   belongs_to :user
   has_one_attached :image
 
-
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :category
   belongs_to_active_hash :status
@@ -11,9 +10,9 @@ class Item < ApplicationRecord
   belongs_to_active_hash :shipping_day
 
   with_options presence: true do
-  validates :image, :item_name, :text, :category, :status, :delivery_fee,
-            :option, :shipping_day
-  validates :price, numericality: { only_integer: true }, inclusion: {in: 300..9999999}
+    validates :image, :item_name, :text, :category, :status, :delivery_fee,
+              :option, :shipping_day
+    validates :price, numericality: { only_integer: true }, inclusion: {in: 300..9_999_999}
   end
 
   validates :category_id, :status_id, :delivery_fee_id, :option_id,

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -2,21 +2,20 @@ class Option < ActiveHash::Base
   self.data = [
     {id: 1, name: '--'},
     {id: 2, name: '北海道'}, {id: 3, name: '青森県'}, {id: 4, name: '岩手県'},
-      {id: 5, name: '宮城県'}, {id: 6, name: '秋田県'}, {id: 7, name: '山形県'},
-      {id: 8, name: '福島県'}, {id: 9, name: '茨城県'}, {id: 10, name: '栃木県'},
-      {id: 11, name: '群馬県'}, {id: 12, name: '埼玉県'}, {id: 13, name: '千葉県'},
-      {id: 14, name: '東京都'}, {id: 15, name: '神奈川県'}, {id: 16, name: '新潟県'},
-      {id: 17, name: '富山県'}, {id: 18, name: '石川県'}, {id: 19, name: '福井県'},
-      {id: 20, name: '山梨県'}, {id: 21, name: '長野県'}, {id: 22, name: '岐阜県'},
-      {id: 23, name: '静岡県'}, {id: 24, name: '愛知県'}, {id: 25, name: '三重県'},
-      {id: 26, name: '滋賀県'}, {id: 27, name: '京都府'}, {id: 28, name: '大阪府'},
-      {id: 29, name: '兵庫県'}, {id: 30, name: '奈良県'}, {id: 31, name: '和歌山県'},
-      {id: 32, name: '鳥取県'}, {id: 33, name: '島根県'}, {id: 34, name: '岡山県'},
-      {id: 35, name: '広島県'}, {id: 36, name: '山口県'}, {id: 37, name: '徳島県'},
-      {id: 38, name: '香川県'}, {id: 39, name: '愛媛県'}, {id: 40, name: '高知県'},
-      {id: 41, name: '福岡県'}, {id: 42, name: '佐賀県'}, {id: 43, name: '長崎県'},
-      {id: 44, name: '熊本県'}, {id: 45, name: '大分県'}, {id: 46, name: '宮崎県'},
-      {id: 47, name: '鹿児島県'}, {id: 48, name: '沖縄県'}
+    {id: 5, name: '宮城県'}, {id: 6, name: '秋田県'}, {id: 7, name: '山形県'},
+    {id: 8, name: '福島県'}, {id: 9, name: '茨城県'}, {id: 10, name: '栃木県'},
+    {id: 11, name: '群馬県'}, {id: 12, name: '埼玉県'}, {id: 13, name: '千葉県'},
+    {id: 14, name: '東京都'}, {id: 15, name: '神奈川県'}, {id: 16, name: '新潟県'},
+    {id: 17, name: '富山県'}, {id: 18, name: '石川県'}, {id: 19, name: '福井県'},
+    {id: 20, name: '山梨県'}, {id: 21, name: '長野県'}, {id: 22, name: '岐阜県'},
+    {id: 23, name: '静岡県'}, {id: 24, name: '愛知県'}, {id: 25, name: '三重県'},
+    {id: 26, name: '滋賀県'}, {id: 27, name: '京都府'}, {id: 28, name: '大阪府'},
+    {id: 29, name: '兵庫県'}, {id: 30, name: '奈良県'}, {id: 31, name: '和歌山県'},
+    {id: 32, name: '鳥取県'}, {id: 33, name: '島根県'}, {id: 34, name: '岡山県'},
+    {id: 35, name: '広島県'}, {id: 36, name: '山口県'}, {id: 37, name: '徳島県'},
+    {id: 38, name: '香川県'}, {id: 39, name: '愛媛県'}, {id: 40, name: '高知県'},
+    {id: 41, name: '福岡県'}, {id: 42, name: '佐賀県'}, {id: 43, name: '長崎県'},
+    {id: 44, name: '熊本県'}, {id: 45, name: '大分県'}, {id: 46, name: '宮崎県'},
+    {id: 47, name: '鹿児島県'}, {id: 48, name: '沖縄県'}
   ]
-  end
- 
+end

--- a/app/models/shipping_day.rb
+++ b/app/models/shipping_day.rb
@@ -5,5 +5,4 @@ class ShippingDay < ActiveHash::Base
     { id: 3, name: '2〜3日で発送' },
     { id: 4, name: '4〜7日で発送' }
   ]
-  end
- 
+end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -8,5 +8,4 @@ class Status < ActiveHash::Base
     { id: 6, name: '傷や汚れあり' },
     { id: 7, name: '全体的に状態が悪い' }
   ]
-  end
- 
+end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :category do
-    
   end
 end

--- a/spec/factories/delivery_fees.rb
+++ b/spec/factories/delivery_fees.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :delivery_fee do
-    
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,18 +1,17 @@
 FactoryBot.define do
   factory :item do
-    item_name        {"負け犬"}
-    text             {"自分自身に負けた者"}
+    item_name        { '負け犬' }
+    text             { '自分自身に負けた者' }
     category_id         { 2 }
     status_id           { 2 }
     delivery_fee_id     { 2 }
     option_id           { 2 }
     shipping_day_id     { 2 }
-    price            {"90000"}
+    price {'90000'}
     association :user
 
     after(:build) do |item|
       item.image.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')
     end
- 
   end
 end

--- a/spec/factories/options.rb
+++ b/spec/factories/options.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :option do
-    
   end
 end

--- a/spec/factories/shipping_days.rb
+++ b/spec/factories/shipping_days.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :shipping_day do
-    
   end
 end

--- a/spec/factories/statuses.rb
+++ b/spec/factories/statuses.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :status do
-    
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     password = Faker::Internet.password(min_length: 6)
     password {password}
     password_confirmation { password }
-    first_name            { "孝之" }
-    last_name             { "阿部" }
+    first_name            { '孝之' }
+    last_name             { '阿部' }
     first_name_kana       { 'タカユキ' }
     last_name_kana        { 'アベ' }
     birthday              { '1930-01-01' }

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -7,69 +7,69 @@ describe Item, type: :model do
 
   describe '新規商品出品登録' do
     context '新規登録がうまくいくとき' do
-      it "image、item_nameとtext、 categoryとstatus、 delivery_feeとoption、shipping_dayとpriceがあれば登録できる" do
+      it 'image、item_nameとtext、 categoryとstatus、 delivery_feeとoption、shipping_dayとpriceがあれば登録できる' do
         expect(@item).to be_valid
       end
-      it "priceが¥300~¥9,999,999の間であれば登録できる" do
-        @item.price = "9999999"
+      it 'priceが¥300~¥9,999,999の間であれば登録できる' do
+        @item.price = '9999999'
         expect(@item).to be_valid
       end
-      it "priceが半角数字であれば登録できる" do
-        @item.price = "50000"
+      it 'priceが半角数字であれば登録できる' do
+        @item.price = '50000'
         expect(@item).to be_valid
       end
     end
 
     context '新規商品出品登録がうまくいかないとき' do
-      it "imageが無いと登録できない" do
+      it 'imageが無いと登録できない' do
         @item.image = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Image can't be blank")
       end
-      it "item_nameが空だと登録できない" do
+      it 'item_nameが空だと登録できない' do
         @item.item_name = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Item name can't be blank")
       end
-      it "textが空では登録できない" do
+      it 'textが空では登録できない' do
         @item.text = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Text can't be blank")
       end
-      it "statusが空では登録できない" do
+      it 'statusが空では登録できない' do
         @item.status = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Status can't be blank")
       end
-      it "delivery_feeが空では登録できない" do
+      it 'delivery_feeが空では登録できない' do
         @item.delivery_fee = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Delivery fee can't be blank")
       end
-      it "optionが空では登録できない" do
+      it 'optionが空では登録できない' do
         @item.option = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Option can't be blank")
       end
-      it "shipping_dayが空では登録できない" do
+      it 'shipping_dayが空では登録できない' do
         @item.shipping_day = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Shipping day can't be blank")
       end
-      it "priceが空では登録できない" do
+      it 'priceが空では登録できない' do
         @item.price = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Price can't be blank")
       end
-      it "priceが¥300~¥9,999,999の範囲外であれば登録できない" do
-        @item.price = "200"
+      it 'priceが¥300~¥9,999,999の範囲外であれば登録できない' do
+        @item.price = '200'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not included in the list")
+        expect(@item.errors.full_messages).to include('Price is not included in the list')
       end
-      it "priceが数字以外では登録できない" do
-        @item.price = "五百"
+      it 'priceが数字以外では登録できない' do
+        @item.price = '五百'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number", "Price is not included in the list")
+        expect(@item.errors.full_messages).to include('Price is not a number', 'Price is not included in the list')
       end
     end
   end


### PR DESCRIPTION
What
出品情報削除機能

Why
ユーザーが自身の出品商品を取り止めすることができるために

https://gyazo.com/7706a5c4f64b284f64f227f2e768dbf3